### PR TITLE
Fix infinite loop when stoning the deathmatch NPC.

### DIFF
--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1488,10 +1488,11 @@ collect_transient_within(container, olist)
 struct obj* container;
 struct obj** olist;
 {
-    struct obj* otmp;
-    for (otmp = container->cobj; otmp; otmp = otmp->nobj) {
+    struct obj *otmp, *next;
+    for (otmp = container->cobj; otmp; otmp = next) {
+        next = otmp->nobj;
         if (otmp->cobj)
-            collect_transient_within(otmp);
+            collect_transient_within(otmp, olist);
 
         if (otmp->transient) {
             obj_extract_self(otmp);


### PR DESCRIPTION
This commit fixes a bug in `collect_transient_within` which would sometimes cause an infinite loop when there were transient objects inside a container, including a statue of the deathmatch NPC.
While testing this, I realised that the deathmatch NPC would sometimes throw projectiles at the player which could then be picked up, so, yes, it is possible to be carrying transient objects. (They don't vanish until the NPC is killed.)
I also notice that stealing the NPC's items doesn't work, which is good, but it seemed to result in his entire inventory being stolen at once; not sure whether that was intended.