### PR TITLE
reduce wordy "bestowed" string in swapchest

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -4814,8 +4814,8 @@ schar swapnum;
         /* playername will be appended to the end */
         /* no spaces - underscores will be converted */
         "a_token_from",
-        "altruistically_donated_by",
-        "bestowed_unto_you_through_the_boundless_generosity_of"
+        "kindly_donated_by",
+        "generously_bestowed_by"
     };
     char *filename = make_swapobj_filename(o);
     if (!filename) return FALSE;


### PR DESCRIPTION
this is a conservative reduction in the character length of very long swapchest item names.

imo, it could be helpful to ensure that all 3 strings are the exact same length; this makes long lists of items easier to read.

        "an_item_shared_by",
        "kindly_donated_by",
        "from_your_friend:"