### PR TITLE
Livelog when the arena opponent is created

### DIFF
--- a/src/hack.c
+++ b/src/hack.c
@@ -2050,6 +2050,7 @@ npc_awakens()
             verbalize("Thou art brave indeed, mortal! Now prove thy prowess!");
     }
     tnnt_globals.deathmatch_started = TRUE;
+    livelog_printf(LL_UMONST, "has entered the Arena");
 }
 
 /* moving onto different terrain;


### PR DESCRIPTION
i have not been able to test this, because my compile is failing for unrelated reasons:

```
make[1]: Entering directory '~/git/tnnt/src'
[CC] files.c
files.c: In function ‘paniclog’:
files.c:3801:43: error: ‘buf’ undeclared (first use in this function)
 3801 |                            version_string(buf), yyyymmdd(now), hhmmss(now),
      |                                           ^~~
files.c:3801:43: note: each undeclared identifier is reported only once for each function it appears in
files.c: In function ‘livelog_write_string’:
files.c:4784:7: error: argument ‘buffer’ doesn’t match prototype
 4784 | char *buffer UNUSED;
      |       ^~~~~~
In file included from ../include/config.h:418,
                 from ../include/hack.h:10,
                 from files.c:8:
../include/extern.h:861:14: error: prototype declaration
  861 | E void FDECL(livelog_write_string, (unsigned int, const char *));
      |              ^~~~~~~~~~~~~~~~~~~~
../include/tradstdc.h:193:21: note: in definition of macro ‘FDECL’
  193 | #define FDECL(f, p) f p
      |                     ^
make[1]: *** [<builtin>: files.o] Error 1
make[1]: Leaving directory '/home/roja/git/tnnt/src'
make: *** [Makefile:169: nethack] Error 2

```