### PR TITLE
Fix: unleash all pets when entering arena portal

### DIFF
--- a/src/do.c
+++ b/src/do.c
@@ -1378,6 +1378,7 @@ boolean at_stairs, falling, portal;
     u.uundetected = 0; /* not hidden, even if means are available */
     /* TNNT: pets/steeds/followers can't use the portal to the arena */
     if (!(Is_deathmatch_level(&u.uz) || on_level(newlevel, &deathmatch_level))) {
+        unleash_all();
         keepdogs(FALSE);
     }
     else if (u.usteed) {


### PR DESCRIPTION
Possibly this should go elsewhere in the file, but i can't compile TNNT.

However, I did test this using plain NetHack; if `unleash_all()` is used in `goto_level`, it unleashes all pets when you enter or exit the quest portal.