### PR TITLE
Replace freenode with Libera.Chat

### DIFF
--- a/sys/unix/sysconf
+++ b/sys/unix/sysconf
@@ -52,7 +52,7 @@ MAXPLAYERS=0
 
 # If not null, added to string "To get local support, " in the support
 # information help.
-SUPPORT=Contact the TNNT admins on freenode irc channel #tnnt
+SUPPORT=Contact the TNNT admins on Libera.Chat IRC channel #tnnt
 
 # If not null, displayed at the end of a panic-save sequence.
 #RECOVER=Run the recover program.


### PR DESCRIPTION
The support message in sys/unix/sysconf still mentions freenode, though the IRC channel has moved from there.