### PR TITLE
Revise the message fix for wearing the Really Cool Shirt

### DIFF
--- a/src/do_wear.c
+++ b/src/do_wear.c
@@ -77,8 +77,8 @@ struct obj *otmp;
         if (otmp->otyp == TOWEL)
             Sprintf(how, " around your %s", body_part(HEAD));
         You("are now wearing %s%s.",
-            otmp->oartifact ? doname(otmp) : obj_is_pname(otmp)
-                                           ? the(otmp_name) : an(otmp_name), how);
+            otmp->oartifact && !undiscovered_artifact(otmp->oartifact) ? bare_artifactname(otmp)
+                : obj_is_pname(otmp) ? the(otmp_name) : an(otmp_name), how);
     }
 }
 


### PR DESCRIPTION
It has been reported on IRC that wearing the Really Cool Shirt resulted in `You are now wearing a +0 T-shirt named The Really Cool Shirt (being worn)`. In testing, I also found that the shirt was handled inconsistently when unidentified, as the message included the beatitude and enchantment for the shirt, but not for ordinary T-shirts.

This was technically a bug in vanilla NetHack that was addressed by commit d9ef68c, whereby artifact armour that could be worn in one move, which doesn't exist in vanilla, was not handled correctly, resulting in `You are now wearing Really Cool Shirt`. I believe a better solution might be to use `doname` in `on_msg` (as `off_msg` does) and add a flag to suppress the 'being worn' part of the description, or to change the message to `f - the uncursed +0 Really Cool Shirt (being worn)` and something like `n - a towel (being worn on your head)` for towels.

In the interest of keeping TNNT close to vanilla, I'm revising the earlier fix here. The message is now `You are now wearing the Really Cool Shirt` if it's identified or `You are now wearing a T-shirt named The Really Cool Shirt` if not.