### PR TITLE
Fix: Ahab 'survived drowning' achievement

### DIFF
--- a/src/mon.c
+++ b/src/mon.c
@@ -2430,9 +2430,9 @@ struct monst *mtmp;
                without an engulf attack) from immediately re-engulfing */
             if (attacktype(mtmp->data, AT_ENGL) && !mtmp->mspec_used)
                 mtmp->mspec_used = rnd(2);
-        }
-        if (is_pool(mtmp->mx, mtmp->my))
+        } else if (is_pool(mtmp->mx, mtmp->my)) {
             tnnt_achieve(A_SURVIVED_DROWNING);
+        }
         u.ustuck = 0;
     }
 }

--- a/src/teleport.c
+++ b/src/teleport.c
@@ -323,7 +323,7 @@ boolean allow_drag;
             }
         }
     }
-    if (u.ustuck && is_pool(u.ustuck->mx, u.ustuck->my))
+    if (u.ustuck && !u.uswallow && is_pool(u.ustuck->mx, u.ustuck->my))
         tnnt_achieve(A_SURVIVED_DROWNING);
     reset_utrap(FALSE);
     u.ustuck = 0;


### PR DESCRIPTION
Some places checked only for u.ustuck and whether the monster was on a
water square -- because u.ustuck is set when engulfed/swallowed as well
as from grab attacks like an eel's, being engulfed by, e.g., an air
elemental flying over the water, then getting expelled a couple turns
later, would trigger this achievement.
