### PR TITLE
Pick arena NPC randomly from ascended heroes pool

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -367,9 +367,10 @@
 #define TNNT_SWAPCHEST_DIR HACKDIR "/swapchest"
 #endif
 
-/* File where we maintain the "last ascender" NPC data for the Deathmatch */
-#ifndef TNNT_NPC_FILE
-#define TNNT_NPC_FILE "npcdata"
+/* Directory where we maintain NPC data files for the Deathmatch, one per
+ * ascended player */
+#ifndef TNNT_NPC_DIR
+#define TNNT_NPC_DIR HACKDIR "/npcfiles"
 #endif
 
 /* Whether to enable the #tnntdebug command (and possibly, in the future, other

--- a/include/extern.h
+++ b/include/extern.h
@@ -876,7 +876,7 @@ E void FDECL(refresh_swap_chest_contents, (struct obj *));
 E boolean FDECL(delete_swapobj_file, (struct obj *));
 #endif
 
-#ifdef TNNT_NPC_FILE
+#ifdef TNNT_NPC_DIR
 E void NDECL(write_npc_data);
 E struct monst* FDECL(create_tnnt_npc, (XCHAR_P, XCHAR_P));
 #endif

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -5521,6 +5521,7 @@ dotnntdebug(VOID_ARGS)
         destroy_nhwindow(en_win);
         en_win = WIN_ERR;
     }
+#ifdef TNNT_NPC_DIR
     else if (response == 'w') {
         write_npc_data();
         pline("Finished writing your data as an NPC.");
@@ -5529,6 +5530,11 @@ dotnntdebug(VOID_ARGS)
         pline("Summoning the NPC deathmatch monster.");
         create_tnnt_npc(u.ux, u.uy);
     }
+#else
+    else {
+        pline("NPC arena monsters not supported in this build.");
+    }
+#endif
     return 0;
 }
 

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -5468,7 +5468,7 @@ dotnntdebug(VOID_ARGS)
              "write out a test npcdeath file", MENU_UNSELECTED);
     any.a_char = 'c';
     add_menu(en_win, NO_GLYPH, &any, flags.lootabc ? 0 : any.a_char, '\0', ATR_NONE,
-             "create a NPC deathmatch monster", MENU_UNSELECTED);
+             "create an NPC deathmatch monster", MENU_UNSELECTED);
     end_menu(en_win, "What would you like to do?");
     if (select_menu(en_win, PICK_ONE, &choice) > 0) {
         response = choice->item.a_char;

--- a/src/end.c
+++ b/src/end.c
@@ -1283,9 +1283,11 @@ int how;
         /* not an else if; getting 100000 nets both of these */
         tnnt_achieve(A_FINISHED_WITH_50000);
 
+#ifdef TNNT_NPC_DIR
     /* store ascender as an NPC */
     if (how == ASCENDED)
         write_npc_data();
+#endif
     /* END TNNT code */
 
     dump_open_log(endtime);

--- a/src/files.c
+++ b/src/files.c
@@ -5060,6 +5060,7 @@ pick_npc_file(VOID_ARGS)
     DIR *d = opendir(TNNT_NPC_DIR);
     int chance = 0;
     struct dirent *de;
+    npcpath[0] = '\0';
     while ((de = readdir(d)) != NULL) {
         if (!strncmp(de->d_name, "NPC-", 4)
             && !rn2(++chance)) {
@@ -5085,13 +5086,19 @@ xchar x, y;
     int pm_num, gender, npc_level, hpmax;
     unsigned short mintrinsics;
     char npcname[BUFSZ], path[BUFSZ];
+    char *npcfilename = pick_npc_file();
     struct monst* npc;
-    Sprintf(path, "%s/%s", TNNT_NPC_DIR, pick_npc_file());
-    npcfile = fopen(path, "r");
-    if (!npcfile) {
-        impossible(
-             "Error opening NPC file '%s' - creating generic mplayer instead",
-                   path);
+    Sprintf(path, "%s/%s", TNNT_NPC_DIR, npcfilename);
+    if (!*npcfilename || !(npcfile = fopen(path, "r"))) {
+        /* NB: in the actual tournament the directory should be stocked with
+         * NPC file(s) in advance, so that users will not see this error even
+         * if they enter the arena before anyone has ascended. */
+        if (!*npcfilename)
+            impossible("No NPC files available - creating mplayer instead");
+        else
+            impossible(
+                     "Error opening NPC file '%s' - creating mplayer instead",
+                       path);
         int mndx = rn1(PM_WIZARD - PM_ARCHEOLOGIST + 1, PM_ARCHEOLOGIST);
         /* special = true better approximates an ascending character... */
         npc = mk_mplayer(&mons[mndx], x, y, TRUE);

--- a/src/sp_lev.c
+++ b/src/sp_lev.c
@@ -1643,9 +1643,11 @@ struct mkroom *croom;
     if (m->align != -(MAX_REGISTERS + 2))
         mtmp = mk_roamer(pm, Amask2align(amask), x, y, m->peaceful);
     else if (PM_ARCHEOLOGIST <= m->id && m->id <= PM_WIZARD) {
+#ifdef TNNT_NPC_DIR
         if (Is_deathmatch_level(&u.uz))
-            create_tnnt_npc(x, y);
+            mtmp = create_tnnt_npc(x, y);
         else
+#endif
             mtmp = mk_mplayer(pm, x, y, FALSE);
     }
     else

--- a/sys/unix/Makefile.top
+++ b/sys/unix/Makefile.top
@@ -267,17 +267,21 @@ install: rootcheck $(GAME) recover $(VARDAT) dungeon spec_levs
 		mkdir -p $(SHELLDIR); fi
 	rm -rf $(INSTDIR) $(VARDIR)
 	-mkdir -p $(INSTDIR) $(INSTDIR)/swapchest
+	-mkdir -p $(INSTDIR) $(VARDIR) $(VARDIR)/npcfiles
 	-mkdir -p $(INSTDIR) $(VARDIR) $(VARDIR)/save
 	-mkdir -p $(INSTDIR) $(VARDIR) $(VARDIR)/whereis
 	if test -d ./-p; then rmdir ./-p; fi
 	-$(CHOWN) $(GAMEUID) $(INSTDIR) $(INSTDIR)/swapchest
 	$(CHGRP) $(GAMEGRP) $(INSTDIR) $(INSTDIR)/swapchest
+	-$(CHOWN) $(GAMEUID) $(INSTDIR) $(VARDIR) $(VARDIR)/npcfiles
+	$(CHGRP) $(GAMEGRP) $(INSTDIR) $(VARDIR) $(VARDIR)/npcfiles
 	-$(CHOWN) $(GAMEUID) $(INSTDIR) $(VARDIR) $(VARDIR)/save
 	$(CHGRP) $(GAMEGRP) $(INSTDIR) $(VARDIR) $(VARDIR)/save
 	-$(CHOWN) $(GAMEUID) $(INSTDIR) $(VARDIR) $(VARDIR)/whereis
 	$(CHGRP) $(GAMEGRP) $(INSTDIR) $(VARDIR) $(VARDIR)/whereis
 # order counts here:
 	chmod $(DIRPERM) $(INSTDIR) $(INSTDIR)/swapchest
+	chmod $(VARDIRPERM) $(VARDIR) $(VARDIR)/npcfiles
 	chmod $(VARDIRPERM) $(VARDIR) $(VARDIR)/save
 	chmod $(VARDIRPERM) $(VARDIR) $(VARDIR)/whereis
 # set up the game files


### PR DESCRIPTION
Instead of using the hero who ascended most recently as the guaranteed
arena opponent, keep separate files for each player (per player, not per
hero, so the odds will stay reasonable even if someone ascends a huge
number of times) who has ascended, and select one at random to use when
creating a new deathmatch NPC.
