### PR TITLE
Fix: crash entering Astral

### DIFF
--- a/src/do.c
+++ b/src/do.c
@@ -1396,11 +1396,13 @@ boolean at_stairs, falling, portal;
         for (mtmp = mydogs; mtmp; mtmp = mtmp->nmon) {
             tnnt_globals.num_planes_pets++;
         }
-        tnnt_globals.planes_pet_m_ids = (unsigned int *)
-            alloc(tnnt_globals.num_planes_pets * sizeof(unsigned int));
-        for (mtmp = mydogs; mtmp; mtmp = mtmp->nmon) {
-            tnnt_globals.planes_pet_m_ids[i] = mtmp->m_id;
-            i++;
+        if (tnnt_globals.num_planes_pets) {
+            tnnt_globals.planes_pet_m_ids = (unsigned int *)
+                alloc(tnnt_globals.num_planes_pets * sizeof(unsigned int));
+            for (mtmp = mydogs; mtmp; mtmp = mtmp->nmon) {
+                tnnt_globals.planes_pet_m_ids[i] = mtmp->m_id;
+                i++;
+            }
         }
     }
     if (Is_astralevel(newlevel)) {
@@ -1423,7 +1425,8 @@ boolean at_stairs, falling, portal;
         /* This is technically a memory leak if the player dies on the Planes
          * before getting to astral, but the game will be ending anyway so it's
          * not that important. */
-        free((genericptr_t) tnnt_globals.planes_pet_m_ids);
+        if (tnnt_globals.num_planes_pets)
+            free((genericptr_t) tnnt_globals.planes_pet_m_ids);
         tnnt_globals.planes_pet_m_ids = (unsigned int *) 0;
     }
     /* end TNNT */


### PR DESCRIPTION
If the player had no pets when entering Earth, the game could crash when
entering Astral, apparently related to code of the form

    planes_pet_m_ids = alloc(num_pets); /* num_pets == 0 */
    /* ... */
    free((genericptr_t) planes_pet_m_ids);

The C standard suggests the result from malloc(0) should be safe to give
to free(), but for some reason this is causing problems -- maybe the
difference between malloc() and NetHack's alloc().  I wasn't able to
reproduce it myself so it may depend on the OS/standard library/etc, or
maybe some compile-time settings for NetHack that change how alloc()
works... anyway, preventing the alloc() and free() unless num_pets is
nonzero seems to fix it, whatever is causing it.
