### PR TITLE
Don't leak b/u/c of item put into swap chest

### DIFF
--- a/src/files.c
+++ b/src/files.c
@@ -4836,11 +4836,9 @@ schar swapnum;
                o->cursed, o->blessed, o->oeroded, o->oeroded2, o->oerodeproof,
                o->recharged, o->greased, o->usecount, o->corpsenm, objnames[swapnum], plname);
     /* the second line is just for humans to read what the object is, for debugging */
-    o->known = 1;
-    o->dknown = 1;
-    o->bknown = 1;
-    o->rknown = 1;
-    fprintf(f, "%s\n", killer_xname(o));
+    iflags.override_ID = 1;
+    fprintf(f, "%s\n", doname(o));
+    iflags.override_ID = 0;
     fclose(f);
     return TRUE;
 }


### PR DESCRIPTION
In order to print the item's full name in the swapchest file, its
bknown, rknown, and so on, were all being set to 1 when writing the
file, which caused the message 'you put \<item\> into the swap chest' to
include information about b/u/c status, etc.  This could be used to
learn whether a stack of scrolls is blessed or not, by splitting the
stack, putting in one scroll, and then naming the other scrolls based on
what was printed in the 'you put it into the swapchest' message.

It is possible to abuse the swapchest for ID of a particular type of
item, if you can tell from the contents which item you just added, so
it's already leaking information and this doesn't exactly 'plug a
serious leak' -- but it also just seems weird to print that the scroll
is 'blessed' even though you have no way of knowing that.
