### PR TITLE
Fix: dragon egg hatching and achievements

### DIFF
--- a/src/timeout.c
+++ b/src/timeout.c
@@ -842,12 +842,11 @@ long timeout;
                 if ((yours && !silent)
                     || (carried(egg) && mon->data->mlet == S_DRAGON)) {
                     if (tamedog(mon, (struct obj *) 0)) {
-                        if (carried(egg) && mon->data->mlet != S_DRAGON) {
+                        if (carried(egg) && mon->data->mlet != S_DRAGON)
                             mon->mtame = 20;
-                            u.uconduct.pets++;
-                            if (!egg->spe)
-                                tnnt_achieve(A_HATCHED_FOREIGN_EGG);
-                        }
+                        u.uconduct.pets++;
+                        if (!egg->spe)
+                            tnnt_achieve(A_HATCHED_FOREIGN_EGG);
                     }
                 }
                 if (mvitals[mnum].mvflags & G_EXTINCT)


### PR DESCRIPTION
The 'if it's not a dragon egg' check in hatch_egg was originally used to set tameness for recently hatched non-dragons, but ended up being applied to pet tracking and the 'father figure' achievement as well.
