### PR TITLE
Silence many compiler warnings

### DIFF
--- a/include/extern.h
+++ b/include/extern.h
@@ -871,7 +871,7 @@ E void NDECL(mk_dgl_extrainfo);
 #endif
 
 #ifdef TNNT_SWAPCHEST_DIR
-E boolean FDECL(write_swapobj_file, (struct obj *, schar));
+E boolean FDECL(write_swapobj_file, (struct obj *, SCHAR_P));
 E void FDECL(refresh_swap_chest_contents, (struct obj *));
 E boolean FDECL(delete_swapobj_file, (struct obj *));
 #endif

--- a/src/allmain.c
+++ b/src/allmain.c
@@ -669,23 +669,23 @@ newgame()
     /* Create the lost Scrolls of Missing Code, then send them to various places
      * in the Dungeons of Doom. */
     for (i = 0; i < NUM_MISSING_CODE_SCROLLS; ++i) {
-        struct obj* scroll = mksobj(SCR_MISSING_CODE, FALSE, FALSE);
+        struct obj *scroll = mksobj(SCR_MISSING_CODE, FALSE, FALSE);
+        xchar castle_depth = stronghold_level.dlevel;
+        xchar dest;
+        boolean samelevel;
 
         /* TODO: More fine-grained control over where these end up.
          * Currently they just get sent to random levels. */
         tnnt_globals.missing_scroll_levels[i] = 0;
-        xchar castle_depth = stronghold_level.dlevel;
-        xchar dest;
-        boolean samelevel;
         do {
-            // We don't want to put it on dungeon level 1, the Castle, or
-            // Medusa. Since level 1 and the Castle are the extremes, we can
-            // eliminate them in here, though.
+            int j;
+            /* We don't want to put it on dungeon level 1, the Castle, or
+               Medusa. Since level 1 and the Castle are the extremes, we can
+               eliminate them in here, though. */
             dest = rnd(castle_depth - 2) + 1;
 
-            // Don't put two scrolls on the same level.
-            // TODO: This may not be needed.
-            int j;
+            /* Don't put two scrolls on the same level. */
+            /* TODO: This may not be needed. */
             samelevel = FALSE;
             for (j = 0; j < i; ++j) {
                 if (dest == tnnt_globals.missing_scroll_levels[j]) {
@@ -697,7 +697,7 @@ newgame()
         tnnt_globals.missing_scroll_levels[i] = dest;
 
         scroll->owornmask = MIGR_RANDOM;
-        scroll->ox = u.uz.dnum; // should always be DoD
+        scroll->ox = u.uz.dnum; /* should always be DoD */
         scroll->oy = dest;
         /* For devteam feedback on where to find scrolls: store the dest in
          * corpsenm, so we know not to send the hero chasing after a scroll that

--- a/src/botl.c
+++ b/src/botl.c
@@ -412,6 +412,7 @@ const char *
 botl_realtime(void)
 {
     time_t currenttime;
+    static char buf[BUFSZ] = DUMMY;
 
     if (iflags.show_realtime == 'p') {
         /* play time */
@@ -423,7 +424,6 @@ botl_realtime(void)
         return "";
     }
 
-    static char buf[BUFSZ] = { 0 };
     switch (iflags.realtime_format) {
     case 's':
         Sprintf(buf, "%ld", currenttime);

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -5456,11 +5456,11 @@ dotnntdebug(VOID_ARGS)
 {
     char buf[BUFSZ];
     char buf2[BUFSZ];
-    en_win = create_nhwindow(NHW_MENU);
-    menu_item* choice = NULL;
+    menu_item *choice = NULL;
     char response;
     anything any;
     any.a_char = 's';
+    en_win = create_nhwindow(NHW_MENU);
     add_menu(en_win, NO_GLYPH, &any, flags.lootabc ? 0 : any.a_char, '\0', ATR_NONE,
              "show debug stats", MENU_UNSELECTED);
     any.a_char = 'w';
@@ -5482,17 +5482,18 @@ dotnntdebug(VOID_ARGS)
     en_win = WIN_ERR;
 
     if (response == 's') {
-        en_win = create_nhwindow(NHW_MENU);
-        // tnnt achievements
-        putstr(en_win, ATR_BOLD, "TNNT achievements (in hexadecimal):");
         int i;
+        en_win = create_nhwindow(NHW_MENU);
+        /* tnnt achievements */
+        putstr(en_win, ATR_BOLD, "TNNT achievements (in hexadecimal):");
         for (i = 0; i < SIZE(tnnt_globals.tnnt_achievements); ++i) {
-            Sprintf(buf, "tnntachieve%d: 0x%lx", i, tnnt_globals.tnnt_achievements[i]);
+            Sprintf(buf, "tnntachieve%d: 0x%llx", i,
+                    tnnt_globals.tnnt_achievements[i]);
             putstr(en_win, 0, buf);
         }
         putstr(en_win, 0, "");
 
-        // devteam quest info
+        /* devteam quest info */
         putstr(en_win, ATR_BOLD, "Devteam Quest:");
         Strcpy(buf, "Scroll levels:");
         for (i = 0; i < NUM_MISSING_CODE_SCROLLS; ++i) {
@@ -5556,6 +5557,8 @@ boolean final;
 {
     char buf[BUFSZ];
     int i;
+    char eaten[16] = DUMMY;
+    char uneaten[16] = DUMMY;
     en_win = create_nhwindow(NHW_MENU);
 
     /* mention overall #achievements display */
@@ -5725,8 +5728,6 @@ boolean final;
             tnnt_globals.elementals_killed_on_planes[3]);
     putstr(en_win, 0, buf);
 
-    char eaten[16] = DUMMY;
-    char uneaten[16] = DUMMY;
     for (i = 0; i < MAXOCLASSES; ++i) {
         char ochar[2];
         ochar[0] = def_oc_syms[i].sym;
@@ -5763,10 +5764,29 @@ int
 show_tnnt_achievements(final)
 boolean final;
 {
-    menu_item* choice = NULL;
+    menu_item *choice = NULL;
     winid win = create_nhwindow(NHW_MENU);
+    char response, buf[BUFSZ];
+    int i, num_earned = 0;
+
+    /* Special handling for vanilla achievements which are not tracked in
+     * tnnt_achievements. This replicates the conditions in topten.c where they
+     * are added to the xlogfile. */
+    boolean vanilla_achieved[NUM_VANILLA_ACHIEVEMENTS] = {
+        (boolean) u.uachieve.bell,
+        (boolean) u.uachieve.enter_gehennom,
+        (boolean) u.uachieve.menorah,
+        (boolean) u.uachieve.book,
+        (boolean) u.uevent.invoked,
+        (boolean) u.uachieve.amulet,
+        In_endgame(&u.uz),
+        Is_astralevel(&u.uz),
+        (boolean) u.uachieve.mines_luckstone,
+        (boolean) u.uachieve.finish_sokoban,
+        (boolean) u.uachieve.killed_medusa
+    };
+
     start_menu(win);
-    char response;
     if (!final) {
         anything any;
         any.a_char = 'e';
@@ -5794,8 +5814,6 @@ boolean final;
     }
     /* TODO: will need NHW_MENU if we can get paging to work in tty */
     win = create_nhwindow(NHW_TEXT);
-    char buf[BUFSZ];
-    int i;
     if (response == 'b') {
         putstr(win, ATR_BOLD, "All achievements:");
     }
@@ -5807,24 +5825,6 @@ boolean final;
     if (!final) {
         putstr(win, ATR_BOLD, "(Use #tnntstats to check progress of certain ones.)");
     }
-
-    int num_earned = 0;
-    /* Special handling for vanilla achievements which are not tracked in
-     * tnnt_achievements. This replicates the conditions in topten.c where they
-     * are added to the xlogfile. */
-    boolean vanilla_achieved[NUM_VANILLA_ACHIEVEMENTS] = {
-        (boolean) u.uachieve.bell,
-        (boolean) u.uachieve.enter_gehennom,
-        (boolean) u.uachieve.menorah,
-        (boolean) u.uachieve.book,
-        (boolean) u.uevent.invoked,
-        (boolean) u.uachieve.amulet,
-        In_endgame(&u.uz),
-        Is_astralevel(&u.uz),
-        (boolean) u.uachieve.mines_luckstone,
-        (boolean) u.uachieve.finish_sokoban,
-        (boolean) u.uachieve.killed_medusa
-    };
     for (i = 0; i < NUM_VANILLA_ACHIEVEMENTS; ++i) {
         boolean earned = vanilla_achieved[i];
         if (earned)
@@ -5936,10 +5936,11 @@ dotnntspecies(VOID_ARGS)
             putstr(en_win, 0, buf);
             numeligible++;
             if (killed) {
+                char mlet;
                 total++;
                 /* note that mons[].mlet isn't the actual character it displays
                  * as. S_ANT is 1, for instance. */
-                char mlet = mons[i].mlet - S_ANT + 'a';
+                mlet = mons[i].mlet - S_ANT + 'a';
                 if (mlet >= 'a' && mlet <= 'z') {
                     lowercaselets[mlet - 'a'] = mlet;
                 }

--- a/src/files.c
+++ b/src/files.c
@@ -4791,7 +4791,7 @@ VA_DECL2(unsigned int, ll_type, const char *, fmt)
 void
 livelog_write_string(log_type, buffer)
 unsigned int log_type UNUSED;
-char *buffer UNUSED;
+const char *buffer UNUSED;
 {
 }
 
@@ -4828,10 +4828,13 @@ schar swapnum;
         "generously_bestowed_by"
     };
     char *filename = make_swapobj_filename(o);
-    if (!filename) return FALSE;
-    FILE *f = fopen(filename,"w");
+    FILE *f;
+    if (!filename)
+        return FALSE;
+    f = fopen(filename,"w");
     free(filename);
-    if (!f) return FALSE;
+    if (!f)
+        return FALSE;
     fprintf(f, "o_id=%x\totyp=%d\towt=%d\tquan=%ld\tspe=%d\toclass=%d\t"
                "cursed=%d\tblessed=%d\toeroded=%d\toeroded2=%d\toerodeproof=%d\t"
                "recharged=%d\tgreased=%d\tusecount=%d\tcorpsenm=%d\tname=%s_%s\n",
@@ -4984,30 +4987,32 @@ write_npc_data(VOID_ARGS)
 {
     FILE *npcfile;
     char buf[BUFSZ];
+    unsigned short mintrinsics;
+    struct obj *obj;
     Sprintf(buf, "%s/NPC-%s", TNNT_NPC_DIR, plname);
     npcfile = fopen(buf, "w");
     if (!npcfile) {
         impossible("Error writing player data to '%s' file", buf);
         return;
     }
-    // line 1: timestamp
+    /* line 1: timestamp */
     fprintf(npcfile, "%ld\n", program_state.gameover ? urealtime.finish_time
                                                      : time(NULL));
-    // line 2: player name
+    /* line 2: player name */
     fprintf(npcfile, "%s\n", plname);
-    // line 3: player role index and gender
+    /* line 3: player role index and gender */
     fprintf(npcfile, "%d %d\n", (flags.female && urole.femalenum != NON_PM) ?
                                     urole.femalenum : urole.malenum,
                                 flags.female);
-    // line 4: player experience level
+    /* line 4: player experience level */
     fprintf(npcfile, "%d\n", u.ulevel);
-    // line 5: player hit point maximum
+    /* line 5: player hit point maximum */
     fprintf(npcfile, "%d\n", u.uhpmax);
     /* line 6: player intrinsics, converted to mextrinsics format...
      * fire cold shock sleep poison disintegration are the only ones that will
      * actually do anything and that are obtainable by the player intrinsically
      */
-    unsigned short mintrinsics = 0x0;
+    mintrinsics = 0x0;
     if (HFire_resistance & INTRINSIC)
         mintrinsics |= MR_FIRE;
     if (HCold_resistance & INTRINSIC)
@@ -5023,7 +5028,6 @@ write_npc_data(VOID_ARGS)
     fprintf(npcfile, "0x%x\n", mintrinsics);
     /* lines 7-end: carried objects, we preserve only certain fields because
      * others would be pointless... */
-    struct obj* obj;
     for (obj = invent; obj; obj = obj->nobj) {
         /* Items that should be excluded go here.
          * We don't go into cobj, so a container with stuff in it turns into an
@@ -5085,9 +5089,15 @@ xchar x, y;
     unsigned short mintrinsics;
     char npcname[BUFSZ], path[BUFSZ];
     char *npcfilename = pick_npc_file();
-    struct monst* npc;
+    const long int mmflags = (NO_MINVENT | MM_NOCOUNTBIRTH | MM_ADJACENTOK
+                              | MM_ANGRY | MM_ASLEEP);
+    struct obj *obj;
+    int strategy, otyp, quan, spe, cursed, blessed, oerodeproof, recharged,
+        greased, corpsenm, usecount, oeaten;
+    struct monst *npc;
     Sprintf(path, "%s/%s", TNNT_NPC_DIR, npcfilename);
     if (!*npcfilename || !(npcfile = fopen(path, "r"))) {
+        int mndx;
         /* NB: in the actual tournament the directory should be stocked with
          * NPC file(s) in advance, so that users will not see this error even
          * if they enter the arena before anyone has ascended. */
@@ -5097,7 +5107,7 @@ xchar x, y;
             impossible(
                      "Error opening NPC file '%s' - creating mplayer instead",
                        path);
-        int mndx = rn1(PM_WIZARD - PM_ARCHEOLOGIST + 1, PM_ARCHEOLOGIST);
+        mndx = rn1(PM_WIZARD - PM_ARCHEOLOGIST + 1, PM_ARCHEOLOGIST);
         /* special = true better approximates an ascending character... */
         npc = mk_mplayer(&mons[mndx], x, y, TRUE);
         npc->mcloned = 1;
@@ -5105,23 +5115,22 @@ xchar x, y;
         return npc;
     }
     /* Get base data from the file. */
-    fgets(npcname, BUFSZ, npcfile); // eat up timestamp; game doesn't use it
-    fgets(npcname, BUFSZ, npcfile); // actually read in name this time
-    npcname[strlen(npcname)-1] = '\0'; // strip \n that was read in
-    fscanf(npcfile, "%d %d\n", &pm_num, &gender);  // get PM_* of correct player monster
-    fscanf(npcfile, "%d\n", &npc_level);   // get ascender's XL
-    fscanf(npcfile, "%d\n", &hpmax);   // get ascender's hp max
-    fscanf(npcfile, "0x%hx\n", &mintrinsics); // get ascender's monster-format intrinsics
+    fgets(npcname, BUFSZ, npcfile); /* eat up timestamp; game doesn't use it */
+    fgets(npcname, BUFSZ, npcfile); /* actually read in name this time */
+    npcname[strlen(npcname)-1] = '\0'; /* strip \n that was read in */
+    fscanf(npcfile, "%d %d\n", &pm_num, &gender);  /* get PM_* of correct player monster */
+    fscanf(npcfile, "%d\n", &npc_level);   /* get ascender's XL */
+    fscanf(npcfile, "%d\n", &hpmax);   /* get ascender's hp max */
+    fscanf(npcfile, "0x%hx\n", &mintrinsics); /* get ascender's monster-format intrinsics */
 
     /* Make the monster normally and take care of all the boilerplate. */
-    const long int mmflags = NO_MINVENT | MM_NOCOUNTBIRTH | MM_ADJACENTOK | MM_ANGRY | MM_ASLEEP;
     npc = makemon(&mons[pm_num], x, y, mmflags);
 
     /* Setup! */
     npc->m_lev = max(npc_level, 14);
-    hpmax = min(hpmax, 500); // cap ascender's hpmax at this
-    hpmax = max(hpmax, d((int) npc->m_lev, 10) + 100 + rnd(30)); // beefed up mplayer formula
-    hpmax = max(hpmax, 200); // prevent low HP rolls
+    hpmax = min(hpmax, 500); /* cap ascender's hpmax at this */
+    hpmax = max(hpmax, d((int) npc->m_lev, 10) + 100 + rnd(30)); /* beefed up mplayer formula */
+    hpmax = max(hpmax, 200); /* prevent low HP rolls */
     npc->mhp = npc->mhpmax = hpmax;
     Strcat(npcname, " the ");
     Strcat(npcname, rank_of((int) npc->m_lev, pm_num, gender));
@@ -5142,10 +5151,7 @@ xchar x, y;
     npc->mcloned = 1;
 
     /* Inventory! */
-    struct obj* obj;
-    int strategy = NEED_HTH_WEAPON;
-    int otyp, quan, spe, cursed, blessed, oerodeproof, recharged, greased,
-        corpsenm, usecount, oeaten;
+    strategy = NEED_HTH_WEAPON;
     while (11 == fscanf(npcfile, "%d %d %d %d %d %d %d %d %d %d %d\n",
                         &otyp, &quan, &spe, &cursed, &blessed, &oerodeproof, &recharged,
                         &greased, &corpsenm, &usecount, &oeaten)) {

--- a/src/hack.c
+++ b/src/hack.c
@@ -581,8 +581,8 @@ dosinkfall()
         You((innate_lev || blockd_lev) ? "wobble unsteadily for a moment."
                                        : "gain control of your flight.");
     } else {
-        tnnt_achieve(A_FELL_ONTO_SINK);
         long save_ELev = ELevitation, save_HLev = HLevitation;
+        tnnt_achieve(A_FELL_ONTO_SINK);
 
         /* fake removal of levitation in advance so that final
            disclosure will be right in case this turns out to
@@ -2545,7 +2545,7 @@ register boolean newlev;
         switch (rt) {
         case VAULT:
             tnnt_achieve(A_ENTERED_VAULT);
-            rt = 0; // don't unmake vault
+            rt = 0; /* don't unmake vault */
             break;
         case ZOO:
             tnnt_achieve(A_ENTERED_ZOO);

--- a/src/lock.c
+++ b/src/lock.c
@@ -21,7 +21,7 @@ STATIC_PTR int NDECL(forcelock);
 STATIC_DCL const char *NDECL(lock_action);
 STATIC_DCL boolean FDECL(obstructed, (int, int, BOOLEAN_P));
 STATIC_DCL void FDECL(chest_shatter_msg, (struct obj *));
-STATIC_DCL void FDECL(tnnt_door_resists, (xchar, xchar));
+STATIC_DCL void FDECL(tnnt_door_resists, (XCHAR_P, XCHAR_P));
 
 boolean
 picking_lock(x, y)

--- a/src/mhitu.c
+++ b/src/mhitu.c
@@ -470,9 +470,9 @@ register struct monst *mtmp;
                      helm_simple_name(obj));
             } else {
                 if (3 + find_mac(mtmp) <= rnd(20)) {
+                    int dmg = d(3, 6);
                     pline("%s is hit by a falling piercer (you)!",
                           Monnam(mtmp));
-                    int dmg = d(3, 6);
                     if ((mtmp->mhp -= dmg) < 1)
                         killed(mtmp);
                 } else
@@ -1477,8 +1477,8 @@ register struct attack *mattk;
         }
         if (!uwep && !uarmu && !uarm && !uarmc
             && !uarms && !uarmg && !uarmf && !uarmh) {
-            tnnt_achieve(A_HEALED_BY_NURSE);
             boolean goaway = FALSE;
+            tnnt_achieve(A_HEALED_BY_NURSE);
 
             pline("%s hits!  (I hope you don't mind.)", Monnam(mtmp));
             if (Upolyd) {

--- a/src/mklev.c
+++ b/src/mklev.c
@@ -1202,10 +1202,10 @@ xchar x, y; /* location */
      */
     br = br->next;
     while (br) {
-        // this logic is stolen from Is_branchlev in dungeon.c
+        /* this logic is stolen from Is_branchlev in dungeon.c */
         if (on_level(&u.uz, &br->end1) || on_level(&u.uz, &br->end2)) {
-            // x=0, y=0 causes the second branch to be randomly placed... this
-            // is fine for TNNT but is not extensible.
+            /* x=0, y=0 causes the second branch to be randomly placed... this 
+               is fine for TNNT but is not extensible. */
             place_branch(br, 0, 0);
         }
         br = br->next;

--- a/src/mon.c
+++ b/src/mon.c
@@ -2147,10 +2147,9 @@ register struct monst *mtmp;
         }
     }
     if (is_deathmatch_opponent(mtmp)) {
+        struct obj *list = collect_all_transient(NULL), *next;
         tnnt_globals.deathmatch_completed = TRUE;
         /* Gather all of the NPC's possessions in the spot of their death. */
-        struct obj* list = collect_all_transient(NULL);
-        struct obj* next;
         if (list) {
             /* TNNT TODO: post 3.7 merge, we should probably stick a string in
              * quest.lua for these arena messages, so they can be printed as a
@@ -2496,6 +2495,9 @@ void
 tnnt_update_ukilled(mndx)
 int mndx;
 {
+    int i, ct = 0;
+    int32_t lowercase_killed = 0x0, uppercase_killed = 0x0;
+    boolean missedany = FALSE;
     /* First: translate monsters that exist in multiple forms. */
     if (mndx == PM_WERERAT)
         mndx = PM_HUMAN_WERERAT;
@@ -2509,10 +2511,6 @@ int mndx;
 
     /* Count the number of monster species that have had at least 1 monster
      * killed. */
-    int i, ct = 0;
-    int32_t lowercase_killed = 0x0,
-            uppercase_killed = 0x0;
-    boolean missedany = FALSE;
     for (i = LOW_PM; i < SPECIAL_PM; ++i) {
         /* Certain species don't count */
         if (!tnnt_common_monst(i))
@@ -2569,7 +2567,7 @@ xkilled(mtmp, xkill_flags)
 struct monst *mtmp;
 int xkill_flags; /* 1: suppress message, 2: suppress corpse, 4: pacifist */
 {
-    int tmp, mndx, x = mtmp->mx, y = mtmp->my;
+    int tmp, mndx, x = mtmp->mx, y = mtmp->my, m_idx;
     struct permonst *mdat;
     struct obj *otmp;
     struct trap *t;
@@ -2586,7 +2584,7 @@ int xkill_flags; /* 1: suppress message, 2: suppress corpse, 4: pacifist */
 
     /* TNNT code for anything that triggers when the player kills a monster
      * goes here. */
-    int m_idx = (mtmp->cham != NON_PM) ? mtmp->cham : monsndx(mtmp->data);
+    m_idx = (mtmp->cham != NON_PM) ? mtmp->cham : monsndx(mtmp->data);
     tnnt_update_ukilled(m_idx); /* killing groups of monsters achievements */
 
     if (mons[m_idx].mlet == S_DRAGON) {
@@ -2815,10 +2813,10 @@ int xkill_flags; /* 1: suppress message, 2: suppress corpse, 4: pacifist */
         You("die...");
         Strcpy(killer.name, "collapsing dungeon");
         done(CRUSHING);
-        // life saving?
+        /* life saving? */
         pline("Unfortunately, you are still buried under tons of rock...");
         done(CRUSHING);
-        // wizards can refuse to die twice, I guess.
+        /* wizards can refuse to die twice, I guess. */
     }
 
     /* adjust alignment points */
@@ -2861,8 +2859,7 @@ int xkill_flags; /* 1: suppress message, 2: suppress corpse, 4: pacifist */
     /* malign was already adjusted for u.ualign.type and randomization */
     adjalign(mtmp->malign);
 
-    if (mtmp->data == &mons[PM_GHOST] && mtmp->former_rank
-        && strlen(mtmp->former_rank) > 0) {
+    if (mtmp->data == &mons[PM_GHOST] && strlen(mtmp->former_rank) > 0) {
         livelog_printf(LL_UMONST, "destroyed %s, the former %s",
                        livelog_mon_nam(mtmp), mtmp->former_rank);
     }

--- a/src/pickup.c
+++ b/src/pickup.c
@@ -1539,8 +1539,8 @@ struct obj* exception;
     for (y = 0; y < ROWNO; ++y) {
         for (x = 0; x < COLNO; ++x) {
             for (otmp = level.objects[x][y]; otmp; otmp = next) {
-                next = otmp->nobj;
                 xchar oldox = otmp->ox, oldoy = otmp->oy;
+                next = otmp->nobj;
                 t_collect(otmp);
                 if (otmp->transient)
                     newsym(oldox, oldoy);
@@ -1654,9 +1654,9 @@ boolean telekinesis; /* not picking it up directly by hand */
     /* TNNT: you're only allowed to remove one item from whatever the NPC drops
      * when they die. Destroy all other transient objects on the level. */
     if (obj->transient && tnnt_globals.deathmatch_completed) {
+        struct obj *list, *next;
         obj->transient = 0; /* don't collect later or run this block again */
         tnnt_globals.deathmatch_prize_oid = obj->o_id;
-        struct obj *list, *next;
         for (list = collect_all_transient(obj); list; list = next) {
             next = list->nobj;
             list->nobj = NULL;

--- a/src/polyself.c
+++ b/src/polyself.c
@@ -1570,10 +1570,10 @@ domindblast()
             continue;
         u_sen = telepathic(mtmp->data) && !mtmp->mcansee;
         if (u_sen || (telepathic(mtmp->data) && rn2(2)) || !rn2(10)) {
+            int dmg = rnd(15);
             You("lock in on %s %s.", s_suffix(mon_nam(mtmp)),
                 u_sen ? "telepathy"
                       : telepathic(mtmp->data) ? "latent telepathy" : "mind");
-            int dmg = rnd(15);
             mtmp->mhp -= dmg;
             if (DEADMONSTER(mtmp))
                 killed(mtmp);

--- a/src/read.c
+++ b/src/read.c
@@ -162,7 +162,7 @@ char *buf;
     const char* rumor;
     if (tshirt->oartifact == ART_REALLY_COOL_SHIRT && rn2(50)
         && (rumor = getrumor(bcsign(tshirt), buf, TRUE)) && *rumor)
-        ; // actually do nothing here
+        ; /* actually do nothing here */
     else
         Strcpy(buf, shirt_msgs[tshirt->o_id % SIZE(shirt_msgs)]);
     return erode_obj_text(tshirt, buf);
@@ -2123,7 +2123,7 @@ struct obj *obj;
 STATIC_OVL void
 do_class_genocide()
 {
-    int i, j, immunecnt, gonecnt, goodcnt, class, feel_dead, ll_done = 0;
+    int i, j, immunecnt, gonecnt, goodcnt, class, feel_dead = 0, ll_done = 0;
     char buf[BUFSZ] = DUMMY;
     boolean gameover = FALSE; /* true iff killed self */
 

--- a/src/topten.c
+++ b/src/topten.c
@@ -379,7 +379,7 @@ int how;
             aligns[1 - u.ualignbase[A_ORIGINAL]].filecode);
     Fprintf(rfile, "%cflags=0x%lx", XLOG_SEP, encodexlogflags());
     for (i = 0; i < SIZE(tnnt_globals.tnnt_achievements); ++i) {
-        Fprintf(rfile, "%ctnntachieve%d=0x%lx", XLOG_SEP, i,
+        Fprintf(rfile, "%ctnntachieve%d=0x%llx", XLOG_SEP, i,
                 tnnt_globals.tnnt_achievements[i]);
     }
     Fprintf(rfile, "\n");

--- a/src/windows.c
+++ b/src/windows.c
@@ -1449,6 +1449,10 @@ boolean onoff;
         if (attrmask & HL_BOLD)
             fprintf(dumphtml_file, BOLD_E);
     }
+#else
+    nhUse(coloridx);
+    nhUse(attrmask);
+    nhUse(onoff);
 #endif
 }
 


### PR DESCRIPTION
Mostly -ansi -pedantic warnings from clang about C99 extensions, comment
formatting, and mixing declarations and code, but there were one or two
"real" warnings in there too (e.g. about using a variable before
initializing it).  I didn't fix a warning for vanilla_achieved[] in
show_tnnt_achievements ("initializer for aggregate is not a compile-time
constant"), nor a couple that are from vanilla 3.6.

I am opening this as a PR because K2 asked me to, but I wouldn't say 
it's strictly necessary or anything like that.  TNNT is probably 
unlikely to be built on any compilers old enough for this to matter, so 
the only real benefit is to silence various warnings for people using 
the OSX hints files (and/or to stay closer to NetHack code style).
